### PR TITLE
Implement EventNotifier/EventConsumer as a generic event notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+### Added
+
+- [[#244](https://github.com/rust-vmm/vmm-sys-util/pull/244)]: Add EventNotifier and EventConsumer as a generic event notification 
+
 ## v0.14.0
 
 ### Changed

--- a/src/fam.rs
+++ b/src/fam.rs
@@ -271,7 +271,7 @@ impl<T: Default + FamStruct> FamStructWrapper<T> {
     /// # Arguments
     ///
     /// * `entries` - The slice of [`FamStruct::Entry`](trait.FamStruct.html#associatedtype.Entry)
-    ///               entries.
+    ///   entries.
     ///
     /// # Errors
     ///
@@ -483,7 +483,7 @@ impl<T: Default + FamStruct> FamStructWrapper<T> {
     /// # Arguments
     ///
     /// * `f` - The function used to evaluate whether an entry will be kept or not.
-    ///         When `f` returns `true` the entry is kept.
+    ///   When `f` returns `true` the entry is kept.
     pub fn retain<P>(&mut self, mut f: P)
     where
         P: FnMut(&T::Entry) -> bool,

--- a/src/linux/aio.rs
+++ b/src/linux/aio.rs
@@ -151,7 +151,7 @@ impl IoContext {
     /// # Arguments
     /// * `iocb`: The iocb for the operation to be canceled.
     /// * `result`: If the operation is successfully canceled, the event will be copied into the
-    ///             memory pointed to by result without being placed into the completion queue.
+    ///   memory pointed to by result without being placed into the completion queue.
     pub fn cancel(&self, iocb: &IoControlBlock, result: &mut IoEvent) -> Result<()> {
         // SAFETY: It's safe because parameters are valid and we have checked the result.
         let rc = unsafe {

--- a/src/linux/epoll.rs
+++ b/src/linux/epoll.rs
@@ -273,9 +273,9 @@ impl Epoll {
     /// # Arguments
     ///
     /// * `timeout` - specifies for how long the `epoll_wait` system call will block
-    ///               (measured in milliseconds).
+    ///   (measured in milliseconds).
     /// * `events` - points to a memory area that will be used for storing the events
-    ///              returned by `epoll_wait()` call.
+    ///   returned by `epoll_wait()` call.
     ///
     /// # Examples
     ///

--- a/src/linux/sock_ctrl_msg.rs
+++ b/src/linux/sock_ctrl_msg.rs
@@ -115,7 +115,7 @@ fn get_next_cmsg(msghdr: &msghdr, cmsg: &cmsghdr, cmsg_ptr: *mut cmsghdr) -> *mu
 const CMSG_BUFFER_INLINE_CAPACITY: usize = CMSG_SPACE!(size_of::<RawFd>() * 32);
 
 enum CmsgBuffer {
-    Inline([u64; (CMSG_BUFFER_INLINE_CAPACITY + 7) / 8]),
+    Inline([u64; CMSG_BUFFER_INLINE_CAPACITY.div_ceil(8)]),
     Heap(Box<[cmsghdr]>),
 }
 
@@ -124,7 +124,7 @@ impl CmsgBuffer {
         let cap_in_cmsghdr_units =
             (capacity.checked_add(size_of::<cmsghdr>()).unwrap() - 1) / size_of::<cmsghdr>();
         if capacity <= CMSG_BUFFER_INLINE_CAPACITY {
-            CmsgBuffer::Inline([0u64; (CMSG_BUFFER_INLINE_CAPACITY + 7) / 8])
+            CmsgBuffer::Inline([0u64; CMSG_BUFFER_INLINE_CAPACITY.div_ceil(8)])
         } else {
             CmsgBuffer::Heap(
                 vec![
@@ -396,10 +396,10 @@ pub trait ScmSocket {
     ///
     /// * `iovecs` - A list of iovec to receive data from the socket.
     /// * `fds` - A slice of `RawFd`s to put the received file descriptors into. On success, the
-    ///           number of valid file descriptors is indicated by the second element of the
-    ///           returned tuple. The caller owns these file descriptors, but they will not be
-    ///           closed on drop like a `File`-like type would be. It is recommended that each valid
-    ///           file descriptor gets wrapped in a drop type that closes it after this returns.
+    ///   number of valid file descriptors is indicated by the second element of the
+    ///   returned tuple. The caller owns these file descriptors, but they will not be
+    ///   closed on drop like a `File`-like type would be. It is recommended that each valid
+    ///   file descriptor gets wrapped in a drop type that closes it after this returns.
     ///
     /// # Safety
     ///

--- a/src/unix/event.rs
+++ b/src/unix/event.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BSD-3-Clause
+//! This is an abstract EventNotifer and EventConsumer for eventfd and pipefd
+
+use std::io::{Read, Write};
+use std::{
+    fs::File,
+    io,
+    os::fd::{AsRawFd, FromRawFd},
+    result,
+};
+
+/// EventNotifier
+/// This is a generic event notifier that can be used with eventfd or pipefd.
+/// It allows writing a value to the file descriptor to notify an event.
+///
+/// # Examples
+///
+/// ```
+/// use std::os::fd::FromRawFd;
+/// use std::os::unix::io::IntoRawFd;
+/// use vmm_sys_util::event::EventNotifier;
+/// let (_, writer) = std::io::pipe().expect("Failed to create pipe");
+/// let notifier = unsafe { EventNotifier::from_raw_fd(writer.into_raw_fd()) };
+/// ```
+#[derive(Debug)]
+pub struct EventNotifier {
+    fd: File,
+}
+
+impl EventNotifier {
+    /// Write a value to the EventNotifier's fd
+    /// Writing 1 to fd is for compatibility with Eventfd
+    pub fn notify(&self) -> result::Result<(), io::Error> {
+        let v = 1u64;
+        (&self.fd).write_all(&v.to_ne_bytes())
+    }
+
+    /// Clone this EventNotifier.
+    pub fn try_clone(&self) -> result::Result<EventNotifier, io::Error> {
+        Ok(EventNotifier {
+            fd: self.fd.try_clone()?,
+        })
+    }
+}
+
+impl AsRawFd for EventNotifier {
+    fn as_raw_fd(&self) -> std::os::unix::prelude::RawFd {
+        self.fd.as_raw_fd()
+    }
+}
+
+/// Convert a raw file descriptor into an EventNotifier.
+impl FromRawFd for EventNotifier {
+    unsafe fn from_raw_fd(fd: std::os::unix::prelude::RawFd) -> Self {
+        EventNotifier {
+            fd: File::from_raw_fd(fd),
+        }
+    }
+}
+
+/// EventReceiver
+/// This is a generic event consumer that can be used with eventfd or pipefd.
+/// It allows reading a value from the file descriptor to consume an event.
+///
+/// # Examples
+///
+/// ```
+/// use std::os::fd::FromRawFd;
+/// use std::os::unix::io::IntoRawFd;
+/// use vmm_sys_util::event::EventConsumer;
+/// let (reader, _) = std::io::pipe().expect("Failed to create pipe");
+/// let consumer = unsafe { EventConsumer::from_raw_fd(reader.into_raw_fd()) };
+/// ```
+#[derive(Debug)]
+pub struct EventConsumer {
+    fd: File,
+}
+
+impl EventConsumer {
+    /// Read a value from the EventConsumer.
+    pub fn consume(&self) -> result::Result<(), io::Error> {
+        let mut buf = [0u8; size_of::<u64>()];
+        (&self.fd).read_exact(buf.as_mut_slice()).map(|_| Ok(()))?
+    }
+
+    /// Clone this EventConsumer.
+    pub fn try_clone(&self) -> result::Result<EventConsumer, io::Error> {
+        Ok(EventConsumer {
+            fd: self.fd.try_clone()?,
+        })
+    }
+}
+
+impl AsRawFd for EventConsumer {
+    fn as_raw_fd(&self) -> std::os::unix::prelude::RawFd {
+        self.fd.as_raw_fd()
+    }
+}
+
+/// Convert a raw file descriptor into an EventConsumer.
+impl FromRawFd for EventConsumer {
+    unsafe fn from_raw_fd(fd: std::os::unix::prelude::RawFd) -> Self {
+        EventConsumer {
+            fd: File::from_raw_fd(fd),
+        }
+    }
+}
+
+/// Create a new EventNotifier and EventConsumer using a pipe.
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+pub fn new_event_notifier_and_consumer(
+) -> std::result::Result<(EventNotifier, EventConsumer), io::Error> {
+    // Use a pipe for non-Linux platforms.
+    let (reader, writer) = std::io::pipe()?;
+    // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+    let notifier = unsafe { EventNotifier::from_raw_fd(writer.into_raw_fd()) };
+    // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+    let consumer = unsafe { EventConsumer::from_raw_fd(reader.into_raw_fd()) };
+    Ok((notifier, consumer))
+}
+
+/// Create a new EventNotifier and EventConsumer using eventfd.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn new_event_notifier_and_consumer(
+) -> std::result::Result<(EventNotifier, EventConsumer), io::Error> {
+    // SAFETY: This is safe because eventfd merely allocated an eventfd for
+    // our process and we handle the error case.
+    let fd = unsafe { libc::eventfd(0, 0) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: This is safe because we made this fd and properly check that it returns
+    // without error.
+    let fd_clone = unsafe { libc::dup(fd) };
+    if fd_clone < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+    let notifier = unsafe { EventNotifier::from_raw_fd(fd) };
+    // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+    let consumer = unsafe { EventConsumer::from_raw_fd(fd_clone) };
+    Ok((notifier, consumer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{io::pipe, os::fd::IntoRawFd};
+
+    #[test]
+    fn test_notify_and_consume() {
+        let (reader, writer) = pipe().expect("Failed to create pipe");
+        // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+        let notifier = unsafe { EventNotifier::from_raw_fd(writer.into_raw_fd()) };
+        // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+        let consumer = unsafe { EventConsumer::from_raw_fd(reader.into_raw_fd()) };
+
+        notifier.notify().unwrap();
+        assert!(consumer.consume().is_ok());
+    }
+
+    #[test]
+    fn test_clone() {
+        let (reader, writer) = pipe().expect("Failed to create pipe");
+        // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+        let notifier = unsafe { EventNotifier::from_raw_fd(writer.into_raw_fd()) };
+        // SAFETY: Safe because we check the fd is valid. And the kernel gave us an fd that we own.
+        let consumer = unsafe { EventConsumer::from_raw_fd(reader.into_raw_fd()) };
+
+        let cloned_notifier = notifier.try_clone().expect("Failed to clone notifier");
+        let cloned_consumer = consumer.try_clone().expect("Failed to clone consumer");
+
+        cloned_notifier.notify().unwrap();
+        assert!(cloned_consumer.consume().is_ok());
+    }
+
+    #[test]
+    fn test_new_event_notifier_and_consumer() {
+        let (notifier, consumer) =
+            new_event_notifier_and_consumer().expect("Failed to create notifier and consumer");
+        notifier.notify().unwrap();
+        assert!(consumer.consume().is_ok());
+    }
+}

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1,5 +1,6 @@
 // Copyright 2022 rust-vmm Authors or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: BSD-3-Clause
+pub mod event;
 pub mod file_traits;
 pub mod tempdir;
 pub mod terminal;


### PR DESCRIPTION
Introduce an abstract event notification in order to support multiple platforms. EventSender is used to send a notification, and EventReceiver is used to receive a notification. The fd used in EventSender or EventReceiver can be from eventfd, pipefd or others.